### PR TITLE
cmake flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,12 +58,12 @@ endif()
 ################################################################################
 # Flags
 ################################################################################
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
 
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -std=c++11)
-set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS}" -arch=sm_35)
+set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS}; -arch=sm_35)
 
 ## Additional debug information
 #set(CUDA_CXX_FLAGS "${CUDA_CXX_FLAGS} -Xptxas=-v --source-in-ptx -rdynamic -lineinfo --keep --keep-dir nvcc_tm")


### PR DESCRIPTION
This small PR makes c++11 the standard for all cmake made c++ execs. Also different spelling in CUDA_NVCC_FLAGS.